### PR TITLE
Adding new ThresholdLine.LabelVerticalPosition.Center option.

### DIFF
--- a/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/ThresholdLinePreviews.kt
+++ b/sample/src/main/java/com/patrykandpatrick/vico/sample/previews/ThresholdLinePreviews.kt
@@ -38,6 +38,7 @@ import com.patrykandpatrick.vico.compose.component.shapeComponent
 import com.patrykandpatrick.vico.compose.component.textComponent
 import com.patrykandpatrick.vico.compose.dimensions.dimensionsOf
 import com.patrykandpatrick.vico.compose.style.LocalChartStyle
+import com.patrykandpatrick.vico.core.chart.addDecorations
 import com.patrykandpatrick.vico.core.chart.decoration.ThresholdLine
 import com.patrykandpatrick.vico.core.component.shape.Shapes
 import com.patrykandpatrick.vico.core.component.shape.shader.ComponentShader
@@ -86,11 +87,24 @@ public fun ThresholdLine() {
         Chart(
             modifier = Modifier,
             chart = columnChart().apply {
-                addDecoration(
-                    ThresholdLine(
-                        thresholdValue = 2f,
-                        lineComponent = shapeComponent(color = Color.Black),
-                        labelComponent = textComponent(Color.Black, padding = dimensionsOf(horizontal = 8.dp)),
+                addDecorations(
+                    listOf(
+                        ThresholdLine(
+                            thresholdValue = 2f,
+                            lineComponent = shapeComponent(color = Color.Black),
+                            labelComponent = textComponent(Color.Black, padding = dimensionsOf(horizontal = 8.dp)),
+                        ),
+                        ThresholdLine(
+                            thresholdValue = 3.5f,
+                            lineComponent = shapeComponent(color = Color.Black),
+                            labelComponent = textComponent(
+                                color = Color.Black,
+                                padding = dimensionsOf(horizontal = 4.dp),
+                                margins = dimensionsOf(horizontal = 4.dp),
+                                background = shapeComponent(color = Color.LightGray),
+                            ),
+                            labelVerticalPosition = ThresholdLine.LabelVerticalPosition.Center,
+                        ),
                     ),
                 )
             },

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/decoration/ThresholdLine.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/decoration/ThresholdLine.kt
@@ -115,6 +115,7 @@ public data class ThresholdLine(
         ).floor
         val textY = when (labelVerticalPosition) {
             LabelVerticalPosition.Top -> topY
+            LabelVerticalPosition.Center -> (topY + bottomY) / 2
             LabelVerticalPosition.Bottom -> bottomY
         }
 
@@ -165,6 +166,7 @@ public data class ThresholdLine(
      */
     public enum class LabelVerticalPosition(public val position: VerticalPosition) {
         Top(VerticalPosition.Top),
+        Center(VerticalPosition.Center),
         Bottom(VerticalPosition.Bottom),
     }
 


### PR DESCRIPTION
This PR adds an option to centre vertically the label of a threshold line. Top and Bottom options were available, but not Center.
I think this one can also be proposed to the library developer. What do you think?

![image](https://github.com/baracodadailyhealthtech/vico/assets/1915259/7a9e425a-8aa6-4fd5-a4dd-0bf1943aeadf)
![image](https://github.com/baracodadailyhealthtech/vico/assets/1915259/062b147a-21cf-4543-b5c9-da4ac72a26a5)
