### PR TITLE
VerticalAxis.HorizontalLabelBehavior option added

### DIFF
--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/axis/vertical/VerticalAxis.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/axis/vertical/VerticalAxis.kt
@@ -46,6 +46,7 @@ import com.patrykandpatrick.vico.core.component.text.TextComponent
  * @param valueFormatter formats the labels.
  * @param sizeConstraint defines how the [VerticalAxis] is to size itself.
  * @param horizontalLabelPosition the horizontal position of the labels.
+ * @param horizontalLabelBehavior the behavior of the horizontal labels.
  * @param verticalLabelPosition the vertical position of the labels.
  * @param itemPlacer determines for what _y_ values the [VerticalAxis] is to display labels, ticks, and guidelines.
  * @param labelRotationDegrees the rotation of the axis labels (in degrees).
@@ -62,6 +63,7 @@ public fun rememberStartAxis(
     valueFormatter: AxisValueFormatter<AxisPosition.Vertical.Start> = DecimalFormatAxisValueFormatter(),
     sizeConstraint: Axis.SizeConstraint = Axis.SizeConstraint.Auto(),
     horizontalLabelPosition: VerticalAxis.HorizontalLabelPosition = VerticalAxis.HorizontalLabelPosition.Outside,
+    horizontalLabelBehavior: VerticalAxis.HorizontalLabelBehavior = VerticalAxis.HorizontalLabelBehavior.HoverContent,
     verticalLabelPosition: VerticalAxis.VerticalLabelPosition = VerticalAxis.VerticalLabelPosition.Center,
     itemPlacer: AxisItemPlacer.Vertical = remember { AxisItemPlacer.Vertical.default() },
     labelRotationDegrees: Float = currentChartStyle.axis.axisLabelRotationDegrees,
@@ -76,6 +78,7 @@ public fun rememberStartAxis(
     tickLengthDp = tickLength.value
     this.sizeConstraint = sizeConstraint
     this.horizontalLabelPosition = horizontalLabelPosition
+    this.horizontalLabelBehavior = horizontalLabelBehavior
     this.verticalLabelPosition = verticalLabelPosition
     this.itemPlacer = itemPlacer
     this.labelRotationDegrees = labelRotationDegrees
@@ -94,6 +97,7 @@ public fun rememberStartAxis(
  * @param valueFormatter formats the labels.
  * @param sizeConstraint defines how the [VerticalAxis] is to size itself.
  * @param horizontalLabelPosition the horizontal position of the labels.
+ * @param horizontalLabelBehavior the behavior of the horizontal labels.
  * @param verticalLabelPosition the vertical position of the labels.
  * @param itemPlacer determines for what _y_ values the [VerticalAxis] is to display labels, ticks, and guidelines.
  * @param labelRotationDegrees the rotation of the axis labels (in degrees).
@@ -110,6 +114,7 @@ public fun rememberEndAxis(
     valueFormatter: AxisValueFormatter<AxisPosition.Vertical.End> = DecimalFormatAxisValueFormatter(),
     sizeConstraint: Axis.SizeConstraint = Axis.SizeConstraint.Auto(),
     horizontalLabelPosition: VerticalAxis.HorizontalLabelPosition = VerticalAxis.HorizontalLabelPosition.Outside,
+    horizontalLabelBehavior: VerticalAxis.HorizontalLabelBehavior = VerticalAxis.HorizontalLabelBehavior.HoverContent,
     verticalLabelPosition: VerticalAxis.VerticalLabelPosition = VerticalAxis.VerticalLabelPosition.Center,
     itemPlacer: AxisItemPlacer.Vertical = remember { AxisItemPlacer.Vertical.default() },
     labelRotationDegrees: Float = currentChartStyle.axis.axisLabelRotationDegrees,
@@ -124,6 +129,7 @@ public fun rememberEndAxis(
     tickLengthDp = tickLength.value
     this.sizeConstraint = sizeConstraint
     this.horizontalLabelPosition = horizontalLabelPosition
+    this.horizontalLabelBehavior = horizontalLabelBehavior
     this.verticalLabelPosition = verticalLabelPosition
     this.itemPlacer = itemPlacer
     this.labelRotationDegrees = labelRotationDegrees
@@ -142,6 +148,7 @@ public fun rememberEndAxis(
  * @param valueFormatter formats the labels.
  * @param sizeConstraint defines how the [VerticalAxis] is to size itself.
  * @param horizontalLabelPosition the horizontal position of the labels.
+ * @param horizontalLabelBehavior the behavior of the horizontal labels.
  * @param verticalLabelPosition the vertical position of the labels.
  * @param maxLabelCount the maximum label count.
  * @param labelRotationDegrees the rotation of the axis labels (in degrees).
@@ -166,6 +173,7 @@ public fun startAxis(
     valueFormatter: AxisValueFormatter<AxisPosition.Vertical.Start> = DecimalFormatAxisValueFormatter(),
     sizeConstraint: Axis.SizeConstraint = Axis.SizeConstraint.Auto(),
     horizontalLabelPosition: VerticalAxis.HorizontalLabelPosition = VerticalAxis.HorizontalLabelPosition.Outside,
+    horizontalLabelBehavior: VerticalAxis.HorizontalLabelBehavior = VerticalAxis.HorizontalLabelBehavior.HoverContent,
     verticalLabelPosition: VerticalAxis.VerticalLabelPosition = VerticalAxis.VerticalLabelPosition.Center,
     maxLabelCount: Int = DEF_LABEL_COUNT,
     labelRotationDegrees: Float = currentChartStyle.axis.axisLabelRotationDegrees,
@@ -180,6 +188,7 @@ public fun startAxis(
     valueFormatter,
     sizeConstraint,
     horizontalLabelPosition,
+    horizontalLabelBehavior,
     verticalLabelPosition,
     remember { AxisItemPlacer.Vertical.default(maxLabelCount) },
     labelRotationDegrees,
@@ -198,6 +207,7 @@ public fun startAxis(
  * @param valueFormatter formats the labels.
  * @param sizeConstraint defines how the [VerticalAxis] is to size itself.
  * @param horizontalLabelPosition the horizontal position of the labels.
+ * @param horizontalLabelBehavior the behavior of the horizontal labels.
  * @param verticalLabelPosition the vertical position of the labels.
  * @param maxLabelCount the maximum label count.
  * @param labelRotationDegrees the rotation of the axis labels (in degrees).
@@ -222,6 +232,7 @@ public fun endAxis(
     valueFormatter: AxisValueFormatter<AxisPosition.Vertical.End> = DecimalFormatAxisValueFormatter(),
     sizeConstraint: Axis.SizeConstraint = Axis.SizeConstraint.Auto(),
     horizontalLabelPosition: VerticalAxis.HorizontalLabelPosition = VerticalAxis.HorizontalLabelPosition.Outside,
+    horizontalLabelBehavior: VerticalAxis.HorizontalLabelBehavior = VerticalAxis.HorizontalLabelBehavior.HoverContent,
     verticalLabelPosition: VerticalAxis.VerticalLabelPosition = VerticalAxis.VerticalLabelPosition.Center,
     maxLabelCount: Int = DEF_LABEL_COUNT,
     labelRotationDegrees: Float = currentChartStyle.axis.axisLabelRotationDegrees,
@@ -236,6 +247,7 @@ public fun endAxis(
     valueFormatter,
     sizeConstraint,
     horizontalLabelPosition,
+    horizontalLabelBehavior,
     verticalLabelPosition,
     remember { AxisItemPlacer.Vertical.default(maxLabelCount) },
     labelRotationDegrees,

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/Charts.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/Charts.kt
@@ -301,7 +301,7 @@ internal fun <Model : ChartEntryModel> ChartImpl(
         wasZoomOverridden = wasZoomOverridden,
         getScroll = { chartScrollState.value },
         scrollBy = { value -> coroutineScope.launch { chartScrollState.scrollBy(value) } },
-        chartBounds = chart.bounds,
+        chartBounds = chart.contentBounds,
     )
 
     Canvas(
@@ -346,12 +346,12 @@ internal fun <Model : ChartEntryModel> ChartImpl(
         var finalZoom = zoom.floatValue
 
         if (!wasZoomOverridden.value || !chartScrollSpec.isScrollEnabled) {
-            finalZoom = measureContext.getAutoZoom(horizontalDimensions, chart.bounds, autoScaleUp)
+            finalZoom = measureContext.getAutoZoom(horizontalDimensions, chart.contentBounds, autoScaleUp)
             if (chartScrollSpec.isScrollEnabled) zoom.floatValue = finalZoom
         }
 
         chartScrollState.maxValue = measureContext.getMaxScrollDistance(
-            chartWidth = chart.bounds.width(),
+            chartWidth = chart.contentBounds.width(),
             horizontalDimensions = horizontalDimensions,
             zoom = finalZoom,
         )
@@ -380,7 +380,7 @@ internal fun <Model : ChartEntryModel> ChartImpl(
         chart.drawScrollableContent(chartDrawContext, model)
 
         fadingEdges?.apply {
-            applyFadingEdges(chartDrawContext, chart.bounds)
+            applyFadingEdges(chartDrawContext, chart.contentBounds)
             chartDrawContext.restoreCanvasToCount(count)
         }
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/BaseChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/BaseChart.kt
@@ -47,6 +47,8 @@ public abstract class BaseChart<in Model : ChartEntryModel> : Chart<Model>, Boun
 
     override val bounds: RectF = RectF()
 
+    override val contentBounds: RectF = RectF()
+
     override val chartInsetters: Collection<ChartInsetter> = persistentMarkers.values
 
     override var axisValuesOverrider: AxisValuesOverrider<@UnsafeVariance Model>? = null
@@ -108,7 +110,7 @@ public abstract class BaseChart<in Model : ChartEntryModel> : Chart<Model>, Boun
             entryLocationMap.getEntryModel(x)?.also { markerModel ->
                 marker.draw(
                     context = context,
-                    bounds = bounds,
+                    bounds = contentBounds,
                     markedEntries = markerModel,
                     chartValuesProvider = chartValuesProvider,
                 )
@@ -130,6 +132,14 @@ public abstract class BaseChart<in Model : ChartEntryModel> : Chart<Model>, Boun
             bottom = bounds.bottom + insets.bottom,
         ) {
             drawDecorationBehindChart(context)
+        }
+
+        canvas.inClip(
+            left = contentBounds.left - insets.getLeft(isLtr),
+            top = contentBounds.top - insets.top,
+            right = contentBounds.right + insets.getRight(isLtr),
+            bottom = contentBounds.bottom + insets.bottom,
+        ) {
             if (model.entries.isNotEmpty()) {
                 drawChart(context, model)
             }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/Chart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/Chart.kt
@@ -16,6 +16,7 @@
 
 package com.patrykandpatrick.vico.core.chart
 
+import android.graphics.RectF
 import com.patrykandpatrick.vico.core.chart.column.ColumnChart
 import com.patrykandpatrick.vico.core.chart.composed.ComposedChart
 import com.patrykandpatrick.vico.core.chart.decoration.Decoration
@@ -33,6 +34,7 @@ import com.patrykandpatrick.vico.core.entry.ChartEntryModel
 import com.patrykandpatrick.vico.core.entry.diff.DrawingModel
 import com.patrykandpatrick.vico.core.entry.diff.ExtraStore
 import com.patrykandpatrick.vico.core.entry.diff.MutableExtraStore
+import com.patrykandpatrick.vico.core.extension.set
 import com.patrykandpatrick.vico.core.marker.Marker
 
 internal const val AXIS_VALUES_DEPRECATION_MESSAGE: String = "Axis values should be overridden via " +
@@ -98,6 +100,9 @@ public interface Chart<in Model> : BoundsAware, ChartInsetter {
      */
     @Deprecated(message = AXIS_VALUES_DEPRECATION_MESSAGE, level = DeprecationLevel.ERROR)
     public var maxX: Float?
+
+    /** Bounds for the chart content (columns, lines, ...) */
+    public val contentBounds: RectF
 
     /**
      * Responsible for drawing the chart itself and any decorations behind it.
@@ -189,6 +194,19 @@ public interface Chart<in Model> : BoundsAware, ChartInsetter {
         horizontalDimensions: MutableHorizontalDimensions,
         model: Model,
     )
+
+    /**
+     * Sets the bounds for the chart content (columns, lines, ...).
+     * Used when labels are configured to push the chart content.
+     */
+    public fun setChartContentBounds(
+        left: Number,
+        top: Number,
+        right: Number,
+        bottom: Number,
+    ) {
+        contentBounds.set(left, top, right, bottom)
+    }
 
     /**
      * Updates the [ChartValues] stored in the provided [ChartValuesManager] instance to this [Chart]’s [ChartValues].

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/column/ColumnChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/column/ColumnChart.kt
@@ -138,7 +138,7 @@ public open class ColumnChart(
         drawingModel: ColumnChartDrawingModel?,
     ) {
         val yRange = (chartValues.maxY - chartValues.minY).takeIf { it != 0f } ?: return
-        val heightMultiplier = bounds.height() / yRange
+        val heightMultiplier = contentBounds.height() / yRange
 
         var drawingStart: Float
         var height: Float
@@ -146,7 +146,7 @@ public open class ColumnChart(
         var column: LineComponent
         var columnTop: Float
         var columnBottom: Float
-        val zeroLinePosition = bounds.bottom + chartValues.minY / yRange * bounds.height()
+        val zeroLinePosition = contentBounds.bottom + chartValues.minY / yRange * contentBounds.height()
 
         model.entries.forEachIndexed { index, entryCollection ->
 
@@ -156,7 +156,7 @@ public open class ColumnChart(
             entryCollection.forEachInIndexed(chartValues.minX..chartValues.maxX) { entryIndex, entry, _ ->
 
                 val columnInfo = drawingModel?.getOrNull(index)?.get(entry.x)
-                height = (columnInfo?.height ?: (abs(entry.y) / chartValues.lengthY)) * bounds.height()
+                height = (columnInfo?.height ?: (abs(entry.y) / chartValues.lengthY)) * contentBounds.height()
                 val xSpacingMultiplier = (entry.x - chartValues.minX) / chartValues.xStep
                 check(xSpacingMultiplier % 1f == 0f) { "Each entry’s x value must be a multiple of the x step." }
                 columnCenterX = drawingStart +
@@ -195,7 +195,7 @@ public open class ColumnChart(
                         top = columnTop,
                         bottom = columnBottom,
                         centerX = columnCenterX,
-                        boundingBox = bounds,
+                        boundingBox = contentBounds,
                         thicknessScale = zoom,
                     )
                 ) {
@@ -289,14 +289,14 @@ public open class ColumnChart(
                 rotationDegrees = dataLabelRotationDegrees,
             ).coerceAtMost(maximumValue = maxWidth)
 
-            if (x - dataLabelWidth.half > bounds.right || x + dataLabelWidth.half < bounds.left) return
+            if (x - dataLabelWidth.half > contentBounds.right || x + dataLabelWidth.half < contentBounds.left) return
 
             val labelVerticalPosition =
                 if (dataLabelValue < 0f) dataLabelVerticalPosition.negative() else dataLabelVerticalPosition
 
             val verticalPosition = labelVerticalPosition.inBounds(
                 y = y,
-                bounds = bounds,
+                bounds = contentBounds,
                 componentHeight = textComponent.getHeight(
                     context = this,
                     text = text,
@@ -323,10 +323,10 @@ public open class ColumnChart(
         column: LineComponent,
         index: Int,
     ) {
-        if (columnCenterX > bounds.left - 1 && columnCenterX < bounds.right + 1) {
+        if (columnCenterX > contentBounds.left - 1 && columnCenterX < contentBounds.right + 1) {
             entryLocationMap.put(
                 x = columnCenterX,
-                y = columnTop.coerceIn(bounds.top, bounds.bottom),
+                y = columnTop.coerceIn(contentBounds.top, contentBounds.bottom),
                 entry = entry,
                 color = column.color,
                 index = index,
@@ -404,7 +404,7 @@ public open class ColumnChart(
 
             MergeMode.Stack -> 0f
         }
-        return bounds.getStart(isLtr) + (
+        return contentBounds.getStart(isLtr) + (
             horizontalDimensions.startPadding +
                 (mergeModeComponent - getColumnCollectionWidth(entryCollectionCount).half) * zoom
             ) * layoutDirectionMultiplier

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/composed/ComposedChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/composed/ComposedChart.kt
@@ -55,6 +55,8 @@ public class ComposedChart<Model : ChartEntryModel>(
 
     private val tempInsets = Insets()
 
+    private val tempContentInsets = Insets()
+
     override val entryLocationMap: TreeMap<Float, MutableList<Marker.EntryModel>> = TreeMap()
 
     override val chartInsetters: Collection<ChartInsetter>
@@ -79,6 +81,11 @@ public class ComposedChart<Model : ChartEntryModel>(
     override fun setBounds(left: Number, top: Number, right: Number, bottom: Number) {
         this.bounds.set(left, top, right, bottom)
         charts.forEach { chart -> chart.setBounds(left, top, right, bottom) }
+    }
+
+    override fun setChartContentBounds(left: Number, top: Number, right: Number, bottom: Number) {
+        super.setChartContentBounds(left, top, right, bottom)
+        charts.forEach { chart -> chart.setChartContentBounds(left, top, right, bottom) }
     }
 
     override fun drawChart(
@@ -135,10 +142,16 @@ public class ComposedChart<Model : ChartEntryModel>(
         }
     }
 
-    override fun getHorizontalInsets(context: MeasureContext, availableHeight: Float, outInsets: HorizontalInsets) {
+    override fun getHorizontalInsets(
+        context: MeasureContext,
+        availableHeight: Float,
+        outInsets: HorizontalInsets,
+        outContentInsets: HorizontalInsets,
+    ) {
         charts.forEach { chart ->
-            chart.getHorizontalInsets(context, availableHeight, tempInsets)
+            chart.getHorizontalInsets(context, availableHeight, tempInsets, tempContentInsets)
             outInsets.setValuesIfGreater(start = tempInsets.start, end = tempInsets.end)
+            outContentInsets.setValuesIfGreater(start = tempContentInsets.start, end = tempContentInsets.end)
         }
     }
 

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/draw/ChartDrawContextExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/draw/ChartDrawContextExtensions.kt
@@ -95,7 +95,7 @@ public fun <Model : ChartEntryModel> ChartDrawContext.drawMarker(
         ?.let { markerEntryModels ->
             marker.draw(
                 context = this,
-                bounds = chart.bounds,
+                bounds = chart.contentBounds,
                 markedEntries = markerEntryModels,
                 chartValuesProvider = chartValuesProvider,
             )

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/insets/ChartInsetter.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/insets/ChartInsetter.kt
@@ -56,5 +56,6 @@ public interface ChartInsetter {
         context: MeasureContext,
         availableHeight: Float,
         outInsets: HorizontalInsets,
+        outContentInsets: HorizontalInsets,
     ): Unit = Unit
 }

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/line/LineChart.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/line/LineChart.kt
@@ -298,12 +298,12 @@ public open class LineChart(
             lineBackgroundPath.rewind()
             val component = lines.getRepeating(entryListIndex)
 
-            var prevX = bounds.getStart(isLtr = isLtr)
-            var prevY = bounds.bottom
+            var prevX = contentBounds.getStart(isLtr = isLtr)
+            var prevY = contentBounds.bottom
 
             val drawingStartAlignmentCorrection = layoutDirectionMultiplier * horizontalDimensions.startPadding
 
-            val drawingStart = bounds.getStart(isLtr = isLtr) + drawingStartAlignmentCorrection - horizontalScroll
+            val drawingStart = contentBounds.getStart(isLtr = isLtr) + drawingStartAlignmentCorrection - horizontalScroll
 
             forEachPointWithinBoundsIndexed(
                 entries = entries,
@@ -313,7 +313,7 @@ public open class LineChart(
                 if (linePath.isEmpty) {
                     linePath.moveTo(x, y)
                     if (component.hasLineBackgroundShader) {
-                        lineBackgroundPath.moveTo(x, bounds.bottom)
+                        lineBackgroundPath.moveTo(x, contentBounds.bottom)
                         lineBackgroundPath.lineTo(x, y)
                     }
                 } else {
@@ -324,7 +324,7 @@ public open class LineChart(
                         x = x,
                         y = y,
                         horizontalDimensions = horizontalDimensions,
-                        bounds = bounds,
+                        bounds = contentBounds,
                     )
                     if (component.hasLineBackgroundShader) {
                         component.pointConnector.connect(
@@ -334,17 +334,17 @@ public open class LineChart(
                             x = x,
                             y = y,
                             horizontalDimensions = horizontalDimensions,
-                            bounds = bounds,
+                            bounds = contentBounds,
                         )
                     }
                 }
                 prevX = x
                 prevY = y
 
-                if (x > bounds.left - 1 && x < bounds.right + 1) {
+                if (x > contentBounds.left - 1 && x < contentBounds.right + 1) {
                     entryLocationMap.put(
                         x = x,
-                        y = y.coerceIn(bounds.top, bounds.bottom),
+                        y = y.coerceIn(contentBounds.top, contentBounds.bottom),
                         entry = entry,
                         color = component.lineColor,
                         index = entryIndex,
@@ -353,9 +353,9 @@ public open class LineChart(
             }
 
             if (component.hasLineBackgroundShader) {
-                lineBackgroundPath.lineTo(prevX, bounds.bottom)
+                lineBackgroundPath.lineTo(prevX, contentBounds.bottom)
                 lineBackgroundPath.close()
-                component.drawBackgroundLine(context, bounds, lineBackgroundPath, drawingModel?.opacity ?: 1f)
+                component.drawBackgroundLine(context, contentBounds, lineBackgroundPath, drawingModel?.opacity ?: 1f)
             }
             component.drawLine(context, linePath, drawingModel?.opacity ?: 1f)
 
@@ -406,7 +406,7 @@ public open class LineChart(
                 )
                 val maxWidth = getMaxDataLabelWidth(chartEntry, x, previousX, nextX)
                 val verticalPosition = lineSpec.dataLabelVerticalPosition.inBounds(
-                    bounds = bounds,
+                    bounds = contentBounds,
                     distanceFromPoint = distanceFromLine,
                     componentHeight = textComponent.getHeight(
                         context = this,
@@ -496,15 +496,15 @@ public open class LineChart(
         var x: Float? = null
         var nextX: Float? = null
 
-        val boundsStart = bounds.getStart(isLtr = isLtr)
-        val boundsEnd = boundsStart + layoutDirectionMultiplier * bounds.width()
+        val boundsStart = contentBounds.getStart(isLtr = isLtr)
+        val boundsEnd = boundsStart + layoutDirectionMultiplier * contentBounds.width()
 
         fun getDrawX(entry: ChartEntry): Float = drawingStart + layoutDirectionMultiplier *
             horizontalDimensions.xSpacing * (entry.x - minX) / xStep
 
         fun getDrawY(entry: ChartEntry): Float =
-            bounds.bottom - (pointInfoMap?.get(entry.x)?.y ?: ((entry.y - chartValues.minY) / chartValues.lengthY)) *
-                bounds.height()
+            contentBounds.bottom - (pointInfoMap?.get(entry.x)?.y ?: ((entry.y - chartValues.minY) / chartValues.lengthY)) *
+                contentBounds.height()
 
         entries.forEachInIndexed(range = minX..maxX, padding = 1) { index, entry, next ->
             val previousX = x

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/layout/VirtualLayout.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/layout/VirtualLayout.kt
@@ -40,7 +40,11 @@ public open class VirtualLayout(
 
     private val finalInsets: Insets = Insets()
 
+    private val finalContentInsets: Insets = Insets()
+
     private val tempInsets: Insets = Insets()
+
+    private val tempContentInsets: Insets = Insets()
 
     /**
      * Measures and sets the bounds for the components of the chart.
@@ -81,8 +85,9 @@ public open class VirtualLayout(
         val availableHeight = contentBounds.height() - finalInsets.vertical - legendHeight
 
         tempInsetters.forEach { insetter ->
-            insetter.getHorizontalInsets(context, availableHeight, tempInsets)
+            insetter.getHorizontalInsets(context, availableHeight, tempInsets, tempContentInsets)
             finalInsets.setValuesIfGreater(tempInsets)
+            finalContentInsets.setValuesIfGreater(tempContentInsets)
         }
 
         val chartBounds = RectF().apply {
@@ -96,6 +101,13 @@ public open class VirtualLayout(
             left = chartBounds.left,
             top = chartBounds.top,
             right = chartBounds.right,
+            bottom = chartBounds.bottom,
+        )
+
+        chart.setChartContentBounds(
+            left = chartBounds.left + finalContentInsets.getLeft(isLtr),
+            top = chartBounds.top,
+            right = chartBounds.right - finalContentInsets.getRight(isLtr),
             bottom = chartBounds.bottom,
         )
 

--- a/vico/views/src/main/java/com/patrykandpatrick/vico/views/chart/BaseChartView.kt
+++ b/vico/views/src/main/java/com/patrykandpatrick/vico/views/chart/BaseChartView.kt
@@ -484,12 +484,12 @@ public abstract class BaseChartView<Model : ChartEntryModel> internal constructo
             var finalZoom = zoom
 
             if (!wasZoomOverridden || !chartScrollSpec.isScrollEnabled) {
-                finalZoom = measureContext.getAutoZoom(horizontalDimensions, chart.bounds, autoScaleUp)
+                finalZoom = measureContext.getAutoZoom(horizontalDimensions, chart.contentBounds, autoScaleUp)
                 if (chartScrollSpec.isScrollEnabled) zoom = finalZoom
             }
 
             scrollHandler.maxValue = measureContext.getMaxScrollDistance(
-                chartWidth = chart.bounds.width(),
+                chartWidth = chart.contentBounds.width(),
                 horizontalDimensions = horizontalDimensions,
                 zoom = finalZoom,
             )
@@ -513,7 +513,7 @@ public abstract class BaseChartView<Model : ChartEntryModel> internal constructo
             chart.drawScrollableContent(chartDrawContext, model)
 
             fadingEdges?.apply {
-                applyFadingEdges(chartDrawContext, chart.bounds)
+                applyFadingEdges(chartDrawContext, chart.contentBounds)
                 chartDrawContext.restoreCanvasToCount(count)
             }
 


### PR DESCRIPTION
When vertical axis labels are drawn inside the chart, they are drawn above the content. In our design, we need the labels to "push" the content inside the chart.

This PR adds this option. Since there was nothing really defining how the various constraints should be applied for Inside labels (or with pretty strange behaviours), I changed the implementation for Inside labels to always give room to the title, and apply the constraint to the labels.
The code responsible for the labels drawing has not been touched, and seems to still behave strangely in some cases.

Initial behaviour, or current one with HorizontalLabelBehavior.HoverContent
![image](https://github.com/baracodadailyhealthtech/vico/assets/1915259/552e8b27-9a8a-44f1-9a80-ab1fe3c10e57)

New behaviour with HorizontalLabelBehavior.PushContent
![image](https://github.com/baracodadailyhealthtech/vico/assets/1915259/89e349fc-7e63-4ece-88f3-c986ef45f442)

