### PR TITLE
Add component graphic override in Column and Line charts

### DIFF
--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/column/ColumnChart.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/column/ColumnChart.kt
@@ -30,6 +30,7 @@ import com.patrykandpatrick.vico.core.chart.composed.ComposedChart
 import com.patrykandpatrick.vico.core.chart.decoration.Decoration
 import com.patrykandpatrick.vico.core.chart.values.AxisValuesOverrider
 import com.patrykandpatrick.vico.core.chart.values.ChartValues
+import com.patrykandpatrick.vico.core.chart.values.ComponentOverrider
 import com.patrykandpatrick.vico.core.component.shape.LineComponent
 import com.patrykandpatrick.vico.core.component.text.TextComponent
 import com.patrykandpatrick.vico.core.component.text.VerticalPosition
@@ -58,6 +59,8 @@ import com.patrykandpatrick.vico.core.marker.Marker
  * @param targetVerticalAxisPosition if this is set, any [AxisRenderer] with an [AxisPosition] equal to the provided
  * value will use the [ChartValues] provided by this chart. This is meant to be used with [ComposedChart].
  * @param drawingModelInterpolator interpolates the [ColumnChart]’s [ColumnChartDrawingModel]s.
+ * @param columnLineComponentOverrider allows overriding some parameters of the default [LineComponent] for a specific
+ * [ChartEntryModel]
  *
  * @see Chart
  * @see ColumnChart
@@ -78,6 +81,7 @@ public fun columnChart(
     axisValuesOverrider: AxisValuesOverrider<ChartEntryModel>? = null,
     drawingModelInterpolator: DrawingModelInterpolator<ColumnChartDrawingModel.ColumnInfo, ColumnChartDrawingModel> =
         remember { DefaultDrawingModelInterpolator() },
+    columnLineComponentOverrider: ComponentOverrider? = null,
 ): ColumnChart = remember { ColumnChart() }.apply {
     this.columns = columns
     this.spacingDp = spacing.value
@@ -90,6 +94,7 @@ public fun columnChart(
     this.axisValuesOverrider = axisValuesOverrider
     this.targetVerticalAxisPosition = targetVerticalAxisPosition
     this.drawingModelInterpolator = drawingModelInterpolator
+    this.columnLineComponentOverrider = columnLineComponentOverrider
     decorations?.also(::setDecorations)
     persistentMarkers?.also(::setPersistentMarkers)
 }

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/line/LineChart.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/line/LineChart.kt
@@ -41,6 +41,7 @@ import com.patrykandpatrick.vico.core.chart.line.LineChart.LineSpec
 import com.patrykandpatrick.vico.core.chart.line.LineChartDrawingModel
 import com.patrykandpatrick.vico.core.chart.values.AxisValuesOverrider
 import com.patrykandpatrick.vico.core.chart.values.ChartValues
+import com.patrykandpatrick.vico.core.chart.values.ComponentOverrider
 import com.patrykandpatrick.vico.core.component.Component
 import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShader
 import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShaders
@@ -65,6 +66,8 @@ import com.patrykandpatrick.vico.core.marker.Marker
  * @param targetVerticalAxisPosition if this is set, any [AxisRenderer] with an [AxisPosition] equal to the provided
  * value will use the [ChartValues] provided by this chart. This is meant to be used with [ComposedChart].
  * @param drawingModelInterpolator interpolates the [LineChart]’s [LineChartDrawingModel]s.
+ * @param pointComponentOverrider allows overriding some parameters of the default point [Component] for a specific
+ * [ChartEntryModel]
  *
  * @see Chart
  * @see ColumnChart
@@ -79,12 +82,14 @@ public fun lineChart(
     targetVerticalAxisPosition: AxisPosition.Vertical? = null,
     drawingModelInterpolator: DrawingModelInterpolator<LineChartDrawingModel.PointInfo, LineChartDrawingModel> =
         remember { DefaultDrawingModelInterpolator() },
+    pointComponentOverrider: ComponentOverrider? = null,
 ): LineChart = remember { LineChart() }.apply {
     this.lines = lines
     this.spacingDp = spacing.value
     this.axisValuesOverrider = axisValuesOverrider
     this.targetVerticalAxisPosition = targetVerticalAxisPosition
     this.drawingModelInterpolator = drawingModelInterpolator
+    this.pointComponentOverrider = pointComponentOverrider
     decorations?.also(::setDecorations)
     persistentMarkers?.also(::setPersistentMarkers)
 }

--- a/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/values/ComponentOverriderExtensions.kt
+++ b/vico/compose/src/main/java/com/patrykandpatrick/vico/compose/chart/values/ComponentOverriderExtensions.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.compose.chart.values
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import com.patrykandpatrick.vico.core.chart.values.ComponentOverrider
+import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShader
+import com.patrykandpatrick.vico.core.entry.ChartEntry
+
+
+/**
+ * Creates and remembers a [ComponentOverrider] instance returning predefined values.
+ *
+ * @param entryMatcher a matcher used to determine if the line component should be overridden or not.
+ * @param color the line component color override provider.
+ */
+@Composable
+public fun rememberOverrideComponent(
+    color: ((ChartEntry) -> Color)? = null,
+    dynamicShader: ((ChartEntry) -> DynamicShader)? = null,
+    strokeColor: ((ChartEntry) -> Color)? = null,
+    entryMatcher: (ChartEntry) -> Boolean,
+): ComponentOverrider {
+    require((color != null) || (dynamicShader != null) || (strokeColor != null)) {
+        "At least one of color, dynamicShader or strokeColor parameters needs to be non null"
+    }
+
+    return remember(entryMatcher, color, strokeColor, dynamicShader) {
+        object : ComponentOverrider {
+            override fun shouldOverride(chartEntry: ChartEntry): Boolean = entryMatcher(chartEntry)
+            override fun getColorOverride(chartEntry: ChartEntry): Int? = color?.invoke(chartEntry)?.toArgb()
+            override fun getShaderOverride(chartEntry: ChartEntry): DynamicShader? = dynamicShader?.invoke(chartEntry)
+            override fun getStrokeColorOverride(chartEntry: ChartEntry): Int? =
+                strokeColor?.invoke(chartEntry)?.toArgb()
+        }
+    }
+}
+
+/**
+ * Creates and remembers a [ComponentOverrider] instance returning predefined values.
+ *
+ * @param entryMatcher a matcher used to determine if the line component should be overridden or not.
+ * @param color the line component color override.
+ */
+@Composable
+public fun rememberOverrideComponent(
+    color: Color? = null,
+    dynamicShader: DynamicShader? = null,
+    strokeColor: Color? = null,
+    entryMatcher: (ChartEntry) -> Boolean,
+): ComponentOverrider {
+    require((color != null) || (dynamicShader != null) || (strokeColor != null)) {
+        "At least one of color, dynamicShader or strokeColor parameters needs to be non null"
+    }
+
+    return remember(entryMatcher, color, strokeColor, dynamicShader) {
+        object : ComponentOverrider {
+            override fun shouldOverride(chartEntry: ChartEntry): Boolean = entryMatcher(chartEntry)
+            override fun getColorOverride(chartEntry: ChartEntry): Int? = color?.toArgb()
+            override fun getShaderOverride(chartEntry: ChartEntry): DynamicShader? = dynamicShader
+            override fun getStrokeColorOverride(chartEntry: ChartEntry): Int? = strokeColor?.toArgb()
+        }
+    }
+}
+
+/**
+ * Creates and remembers a [ComponentOverrider] instance returning predefined values.
+ *
+ * @param entry the specific entry for which the line component should be overridden.
+ * @param color the line component color override.
+ */
+@Composable
+public fun rememberOverrideComponentForEntry(
+    entry: ChartEntry,
+    color: Color? = null,
+    dynamicShader: DynamicShader? = null,
+    strokeColor: Color? = null,
+): ComponentOverrider {
+    return rememberOverrideComponent(
+        entryMatcher = { it == entry },
+        color = color,
+        dynamicShader = dynamicShader,
+        strokeColor = strokeColor,
+    )
+}
+
+/**
+ * Creates and remembers a [ComponentOverrider] instance returning predefined values.
+ *
+ * @param entryIndex the specific entry [index][ChartEntry.x] for which the line component should be overridden.
+ * @param color the line component color override.
+ */
+@Composable
+public fun rememberOverrideComponentForEntryIndex(
+    entryIndex: Float,
+    color: Color? = null,
+    dynamicShader: DynamicShader? = null,
+    strokeColor: Color? = null,
+): ComponentOverrider {
+    return rememberOverrideComponent(
+        entryMatcher = { it.x == entryIndex },
+        color = color,
+        dynamicShader = dynamicShader,
+        strokeColor = strokeColor,
+    )
+}
+
+/**
+ * Creates and remembers a [ComponentOverrider] instance returning predefined values.
+ *
+ * @param entryValue the specific entry [value][ChartEntry.y] for which the line component should be overridden.
+ * @param color the line component color override.
+ */
+@Composable
+public fun rememberOverrideComponentForEntryValue(
+    entryValue: Float,
+    color: Color? = null,
+    dynamicShader: DynamicShader? = null,
+    strokeColor: Color? = null,
+): ComponentOverrider {
+    return rememberOverrideComponent(
+        entryMatcher = { it.y == entryValue },
+        color = color,
+        dynamicShader = dynamicShader,
+        strokeColor = strokeColor,
+    )
+}

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/values/ComponentOverrider.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/values/ComponentOverrider.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.core.chart.values
+
+import com.patrykandpatrick.vico.core.component.shape.LineComponent
+import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShader
+import com.patrykandpatrick.vico.core.entry.ChartEntry
+
+/**
+ * Overrider for Column [line components][LineComponent].
+ */
+public interface ComponentOverrider {
+    /**
+     * @return true when the component associated to the provided [entry][ChartEntry] requires runtime customisation.
+     */
+    public fun shouldOverride(chartEntry: ChartEntry): Boolean = false
+
+    /**
+     * @return the provided [entry][ChartEntry] override color, null when no changes are requested.
+     */
+    public fun getColorOverride(chartEntry: ChartEntry): Int? = null
+
+    /**
+     * @return the provided [entry][ChartEntry] override shader, null when no changes are requested.
+     */
+    public fun getShaderOverride(chartEntry: ChartEntry): DynamicShader? = null
+
+    /**
+     * @return the provided [entry][ChartEntry] override stroke color, null when no changes are requested.
+     */
+    public fun getStrokeColorOverride(chartEntry: ChartEntry): Int? = null
+}

--- a/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/values/ComponentOverriderExtensions.kt
+++ b/vico/core/src/main/java/com/patrykandpatrick/vico/core/chart/values/ComponentOverriderExtensions.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 by Patryk Goworowski and Patrick Michalik.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.patrykandpatrick.vico.core.chart.values
+
+import com.patrykandpatrick.vico.core.component.Component
+import com.patrykandpatrick.vico.core.component.shape.shader.DynamicShader
+import com.patrykandpatrick.vico.core.entry.ChartEntry
+
+/**
+ * Determines and returns the appropriate component to use for the given [chartEntry][ChartEntry].
+ * When no override is necessary, returns the [defaultComponent].
+ * When an override is necessary, it will be provided by [overrideBuilder].
+ */
+internal fun <T : Component> ComponentOverrider?.overrideComponentForEntry(
+    chartEntry: ChartEntry,
+    defaultComponent: T,
+    overrideBuilder: (cacheKey: String, color: Int?, shader: DynamicShader?, strokeColor: Int?) -> T,
+): T {
+    return when {
+        this == null -> defaultComponent
+        shouldOverride(chartEntry) -> {
+            val colorOverride = getColorOverride(chartEntry)
+            val shaderOverride = getShaderOverride(chartEntry)
+            val strokeColorOverride = getStrokeColorOverride(chartEntry)
+            val cacheKey = "$colorOverride##${shaderOverride.hashCode()}##$strokeColorOverride"
+
+            overrideBuilder(cacheKey, colorOverride, shaderOverride, strokeColorOverride)
+        }
+
+        else -> defaultComponent
+    }
+}


### PR DESCRIPTION
This PR adds a way to configure overrides for the Column and Line charts.
In Column charts, the column colour, shader and stroke colour can be overridden.
In Column charts, the point colour, shader and stroke colour can be overridden, for ShapeComponents only.